### PR TITLE
Add/correct author ORCID(s) in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-6745-6796")),
     person("Bronwen", "Lewis", role = "ctb"),
     person("Jill", "Brooks", role = "ctb"),
-    person("Duncan", "Kennedy", role = "ctb"),
+    person("Duncan", "Kennedy", role = "ctb",
+           comment = c(ORCID = "0009-0001-4880-5751")),
     person("Elk Valley Resources", role = c("fnd", "cph"))
   )
 Description: Calculates Growing Season Degree Days (GSDD), Growing Degree


### PR DESCRIPTION
Add Duncan Kennedy's ORCID (0009-0001-4880-5751).

Reviewed across all non-archived, non-forked poissonconsulting R packages to ensure co-authors and contributors carry their correct ORCID iDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)