### PR TITLE
Fix fledge callers (pin @v1, add fledge-tag-on-merge)

### DIFF
--- a/.github/workflows/fledge-bump.yml
+++ b/.github/workflows/fledge-bump.yml
@@ -1,12 +1,19 @@
-  name: fledge-bump
-  on:
-    schedule:
-      - cron: "0 7 * * *"
-    workflow_dispatch:
-  permissions:
-    contents: write
-    pull-requests: write
-  jobs:
-    fledge-bump:
-      uses: poissonconsulting/.github/.github/workflows/fledge-bump.yml@f-fledge-automation@v1
-      secrets: inherit
+# Daily fledge dev-version bump. Calls the reusable engine in poissonconsulting/.github.
+# Requires the org-level secrets FLEDGE_APP_ID and FLEDGE_APP_PRIVATE_KEY (passed via
+# `secrets: inherit`) and the companion fledge-tag-on-merge.yml workflow in this repo.
+
+name: fledge-bump
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fledge-bump:
+    uses: poissonconsulting/.github/.github/workflows/fledge-bump.yml@v1
+    secrets: inherit

--- a/.github/workflows/fledge-tag-on-merge.yml
+++ b/.github/workflows/fledge-tag-on-merge.yml
@@ -1,0 +1,18 @@
+# Tags the dev version on main after a release-path fledge-bump PR merges.
+# Required alongside fledge-bump.yml. Calls the reusable engine in poissonconsulting/.github.
+
+name: fledge-tag-on-merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, master]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'fledge-bump'
+    uses: poissonconsulting/.github/.github/workflows/fledge-tag-on-merge.yml@v1
+    secrets: inherit


### PR DESCRIPTION
gsdd was an early fledge pilot that never re-synced to the `@v1` engine:

- `fledge-bump.yml` pinned `@f-fledge-automation@v1` (an invalid ref) — the daily bump has been **failing**.
- `fledge-tag-on-merge.yml` was missing, so release-version bumps would not get auto-tagged.

Both callers are replaced with the canonical `workflow-templates` from `poissonconsulting/.github` pinned at `@v1`, matching every other package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)