### PR TITLE
Document pick default of "all" (#17)

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -26,10 +26,10 @@
 #' @param msgs A flag specifying whether to provide messages.
 #' @param ncol A count of the number of columns to facet by.
 #' @param nrow A count of the number of rows to facet by.
-#' @param pick A string specifying whether to pick the
-#' "longest", "shortest", "first" or "last" 'season' or the season with the
-#' "biggest" or "smallest" GSDD. By default the returned value is the
-#' the GSDD value for the "longest" 'season'.
+#' @param pick A string specifying which 'season' to pick when more than one
+#' is present. One of "longest", "shortest", "first" or "last", or the season
+#' with the "biggest" or "smallest" GSDD, or "all" to use every season.
+#' By default "all".
 #' @param start_date A Date scalar of the first date
 #' within each year to consider (the year is ignored).
 #' #' If `start_date` occurs before the `end_date` (when ignoring the year)

--- a/man/gdd.Rd
+++ b/man/gdd.Rd
@@ -49,10 +49,10 @@ the start temperature.}
 \item{window_width}{A positive whole number of the
 width of the rolling mean window in days. By default 7.}
 
-\item{pick}{A string specifying whether to pick the
-"longest", "shortest", "first" or "last" 'season' or the season with the
-"biggest" or "smallest" GSDD. By default the returned value is the
-the GSDD value for the "longest" 'season'.}
+\item{pick}{A string specifying which 'season' to pick when more than one
+is present. One of "longest", "shortest", "first" or "last", or the season
+with the "biggest" or "smallest" GSDD, or "all" to use every season.
+By default "all".}
 
 \item{msgs}{A flag specifying whether to provide messages.}
 }

--- a/man/gsdd.Rd
+++ b/man/gsdd.Rd
@@ -52,10 +52,10 @@ the start temperature.}
 \item{window_width}{A positive whole number of the
 width of the rolling mean window in days. By default 7.}
 
-\item{pick}{A string specifying whether to pick the
-"longest", "shortest", "first" or "last" 'season' or the season with the
-"biggest" or "smallest" GSDD. By default the returned value is the
-the GSDD value for the "longest" 'season'.}
+\item{pick}{A string specifying which 'season' to pick when more than one
+is present. One of "longest", "shortest", "first" or "last", or the season
+with the "biggest" or "smallest" GSDD, or "all" to use every season.
+By default "all".}
 
 \item{msgs}{A flag specifying whether to provide messages.}
 }

--- a/man/gsdd_vctr.Rd
+++ b/man/gsdd_vctr.Rd
@@ -42,10 +42,10 @@ the start temperature.}
 \item{window_width}{A positive whole number of the
 width of the rolling mean window in days. By default 7.}
 
-\item{pick}{A string specifying whether to pick the
-"longest", "shortest", "first" or "last" 'season' or the season with the
-"biggest" or "smallest" GSDD. By default the returned value is the
-the GSDD value for the "longest" 'season'.}
+\item{pick}{A string specifying which 'season' to pick when more than one
+is present. One of "longest", "shortest", "first" or "last", or the season
+with the "biggest" or "smallest" GSDD, or "all" to use every season.
+By default "all".}
 
 \item{complete}{A flag specifying whether the vector of water temperatures
 represents the complete possible growing period (by default FALSE).

--- a/man/gss.Rd
+++ b/man/gss.Rd
@@ -52,10 +52,10 @@ the start temperature.}
 \item{window_width}{A positive whole number of the
 width of the rolling mean window in days. By default 7.}
 
-\item{pick}{A string specifying whether to pick the
-"longest", "shortest", "first" or "last" 'season' or the season with the
-"biggest" or "smallest" GSDD. By default the returned value is the
-the GSDD value for the "longest" 'season'.}
+\item{pick}{A string specifying which 'season' to pick when more than one
+is present. One of "longest", "shortest", "first" or "last", or the season
+with the "biggest" or "smallest" GSDD, or "all" to use every season.
+By default "all".}
 
 \item{msgs}{A flag specifying whether to provide messages.}
 }

--- a/man/gss_plot.Rd
+++ b/man/gss_plot.Rd
@@ -55,10 +55,10 @@ the start temperature.}
 \item{window_width}{A positive whole number of the
 width of the rolling mean window in days. By default 7.}
 
-\item{pick}{A string specifying whether to pick the
-"longest", "shortest", "first" or "last" 'season' or the season with the
-"biggest" or "smallest" GSDD. By default the returned value is the
-the GSDD value for the "longest" 'season'.}
+\item{pick}{A string specifying which 'season' to pick when more than one
+is present. One of "longest", "shortest", "first" or "last", or the season
+with the "biggest" or "smallest" GSDD, or "all" to use every season.
+By default "all".}
 
 \item{latex}{A flag specifying whether to use LaTeX to include degree
 symbol in y-axis label.}

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -39,10 +39,10 @@ If NULL then set to be the difference between \code{start_date} and \code{end_da
 
 \item{nrow}{A count of the number of rows to facet by.}
 
-\item{pick}{A string specifying whether to pick the
-"longest", "shortest", "first" or "last" 'season' or the season with the
-"biggest" or "smallest" GSDD. By default the returned value is the
-the GSDD value for the "longest" 'season'.}
+\item{pick}{A string specifying which 'season' to pick when more than one
+is present. One of "longest", "shortest", "first" or "last", or the season
+with the "biggest" or "smallest" GSDD, or "all" to use every season.
+By default "all".}
 
 \item{start_date}{A Date scalar of the first date
 within each year to consider (the year is ignored).


### PR DESCRIPTION
Closes #17

## Summary
Updates the shared `@param pick` roxygen documentation (`R/params.R`) to add the `"all"` option and document it as the default, replacing stale text that named `"longest"` as the default. Regenerated the affected `man/*.Rd` files and fixed a duplicated-word typo.

## Verification
`?gsdd`, `?gss`, `?gdd`, `?gsdd_vctr` and `?gss_plot` now show `pick` defaulting to `"all"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)