### PR TITLE
Assert date_atus() ATU dates explicitly (#10)

### DIFF
--- a/tests/testthat/_snaps/date-atus.md
+++ b/tests/testthat/_snaps/date-atus.md
@@ -154,25 +154,3 @@
         <int> <date>     <date>   <dbl>
       1  2019 1972-01-01 NA          NA
 
-# date_atus picks correct day to exceed 20
-
-    Code
-      date_atus
-    Output
-      # A tibble: 1 x 4
-      # Groups:   year [1]
-         year start_date end_date    atus
-        <int> <date>     <date>     <dbl>
-      1  2019 1972-01-01 1972-01-02    20
-
-# date_atus picks correct day to exceed 600
-
-    Code
-      date_atus
-    Output
-      # A tibble: 1 x 4
-      # Groups:   year [1]
-         year start_date end_date    atus
-        <int> <date>     <date>     <dbl>
-      1  2019 1972-01-01 1972-01-31   600
-

--- a/tests/testthat/test-date-atus.R
+++ b/tests/testthat/test-date-atus.R
@@ -130,9 +130,10 @@ test_that("date_atus picks correct day to exceed 20", {
 
   date_atus <- date_atus(data, start_date = as.Date("2019-01-01"), atu = 20)
 
-  expect_snapshot({
-    date_atus
-  })
+  # Jan 1 contributes 0 and Jan 2 contributes 20, so 20 ATUs are first
+  # reached on Jan 2 (returned as a dayte in the 1972 reference year).
+  expect_identical(date_atus$end_date, as.Date("1972-01-02"))
+  expect_identical(date_atus$atus, 20)
 })
 
 test_that("date_atus picks correct day to exceed 600", {
@@ -147,7 +148,8 @@ test_that("date_atus picks correct day to exceed 600", {
 
   date_atus <- date_atus(data, start_date = as.Date("2019-01-01"), atu = 600)
 
-  expect_snapshot({
-    date_atus
-  })
+  # Cumulative ATUs on Jan d equal 20 * (d - 1), so 600 ATUs are first
+  # reached on Jan 31 (returned as a dayte in the 1972 reference year).
+  expect_identical(date_atus$end_date, as.Date("1972-01-31"))
+  expect_identical(date_atus$atus, 600)
 })


### PR DESCRIPTION
Closes #10

## Summary
Issue #10 asked for a `date_atus()` test using an artificial dataset (0 on Jan 1, 20 every other day) checking the dates where cumulative ATUs reach 20 and 600. That scenario already existed as two snapshot tests; this converts them to explicit assertions so the expected dates are documented inline rather than hidden in a snapshot file.

- 20 ATUs first reached on **Jan 2** (Jan 1 contributes 0, Jan 2 contributes 20).
- 600 ATUs first reached on **Jan 31** (cumulative ATUs on Jan d = 20 * (d - 1)).

The orphaned snapshot entries in `_snaps/date-atus.md` were pruned automatically.

## Verification
`devtools::test(filter = "date-atus")` -> all 18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)